### PR TITLE
Working Patch

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,8 +35,8 @@ jobs:
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.
         override-deps: |
-          ansible==2.10.0
-          ansible-lint==4.2.0
+          ansible==2.11.3
+          ansible-lint==5.1.2
         # [optional]
         # Arguments to be passed to the ansible-lint
 

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,7 +35,7 @@ jobs:
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.
         override-deps: |
-          ansible==2.11.3
+          ansible==2.10.0
           ansible-lint==5.1.2
         # [optional]
         # Arguments to be passed to the ansible-lint

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,2 @@
 [defaults]
 host_key_checking = False
-

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 host_key_checking = False
+

--- a/playbook_deploy_ec2.yml
+++ b/playbook_deploy_ec2.yml
@@ -63,7 +63,8 @@
   become_method: sudo
   
   tasks:
-    - ping:
+    - name: ping 
+      ping:
 
     - name: Create service account
       user:

--- a/playbook_deploy_ec2.yml
+++ b/playbook_deploy_ec2.yml
@@ -61,9 +61,9 @@
   hosts: aws_provisioned
   become: yes
   become_method: sudo
-  
+
   tasks:
-    - name: ping 
+    - name: ping
       ping:
 
     - name: Create service account


### PR DESCRIPTION
Changed ansible-lint version to a newer version then ansible-lint started linting correctly and failing the action because of linting errors. I fixed the linting errors and the Action completed successfully. I also changed the ansible version but this didn't seem to make a difference because in one commit I gave it an invalid ansible version so it just fell back to the initial ansible install and still linted just fine.